### PR TITLE
Updated color scheme to finalize consistent color scheme

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -41,7 +41,7 @@ const StyledSocialLinks = styled.div`
 `;
 
 const StyledCredit = styled.div`
-  color: var(--tertiary-purple);
+  color: var(--dark-brown);
   font-family: var(--font-mono);
   font-size: var(--fz-xxs);
   line-height: 1;

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -59,7 +59,7 @@ const StyledNav = styled.nav`
   ${({ theme }) => theme.mixins.flexBetween};
   position: relative;
   width: 100%;
-  color: var(--dark-blue);
+  color: var(--secondary-green);
   font-family: var(--font-mono);
   counter-reset: item 0;
   z-index: 12;
@@ -120,7 +120,7 @@ const StyledLinks = styled.div`
         &:before {
           content: '0' counter(item) '.';
           margin-right: 5px;
-          color: var(--bright-strawberry);
+          color: var(--secondary-green);
           font-size: var(--fz-xxs);
           text-align: right;
         }

--- a/src/components/scrollToTop.js
+++ b/src/components/scrollToTop.js
@@ -17,10 +17,10 @@ const StyledScrollToTopContainer = styled.div`
     align-items: center;
     width: 30px;
     height: 30px;
-    color: var(--dark-blue);
+    color: var(--secondary-green);
     background-color: transparent;
     border-radius: 50%;
-    border: 1px solid var(--dark-blue);
+    border: 1px solid var(--secondary-green);
     transition: var(--transition);
     margin: 0 auto;
     text-decoration: none;
@@ -31,7 +31,7 @@ const StyledScrollToTopContainer = styled.div`
     &:hover,
     &:focus-visible {
       outline: none;
-      box-shadow: 4px 4px 0 0 var(--dark-blue);
+      box-shadow: 4px 4px 0 0 var(--secondary-green);
       transform: translate(-5px, -5px);
     }
 

--- a/src/components/sections/featured.js
+++ b/src/components/sections/featured.js
@@ -192,7 +192,7 @@ const StyledProject = styled.li`
 
     li {
       margin: 0 20px 5px 0;
-      color: var(--dark-blue);
+      color: var(--secondary-green);
       font-family: var(--font-mono);
       font-size: var(--fz-xs);
       white-space: nowrap;

--- a/src/components/sections/jobs.js
+++ b/src/components/sections/jobs.js
@@ -95,7 +95,7 @@ const StyledTabButton = styled.button`
 
   &:hover,
   &:focus {
-    background-color: var(--tertiary-royal-blue-tint);
+    background-color: var(--soft-green-tint);
   }
 `;
 
@@ -158,7 +158,7 @@ const StyledTabPanel = styled.div`
 
   .range {
     margin-bottom: 25px;
-    color: var(--tertiary-royal-blue);
+    color: var(--secondary-green);
     font-family: var(--font-mono);
     font-size: var(--fz-xs);
   }

--- a/src/components/sections/projects.js
+++ b/src/components/sections/projects.js
@@ -152,7 +152,7 @@ const StyledProject = styled.li`
     padding: 0;
     margin: 20px 0 0 0;
     list-style: none;
-    color: var(--dark-blue);
+    color: var(--secondary-green);
 
     li {
       font-family: var(--font-mono);

--- a/src/components/side.js
+++ b/src/components/side.js
@@ -12,7 +12,7 @@ const StyledSideElement = styled.div`
   left: ${props => (props.orientation === 'left' ? '40px' : 'auto')};
   right: ${props => (props.orientation === 'left' ? 'auto' : '40px')};
   z-index: 10;
-  color: var(--tertiary-royal-blue);
+  color: var(--secondary-green);
 
   @media (max-width: 1080px) {
     left: ${props => (props.orientation === 'left' ? '20px' : 'auto')};


### PR DESCRIPTION
Updated all remaining blue color elements throughout the site to use the same green color (--secondary-green: #629677) as existing accents, creating a more consistent green/orange/black color scheme.

Minor changes include:

- Navigation: Updated nav text and numbered list prefixes from blue to green
- Technology Tags: Changed tech stack tags in projects and featured sections from blue to green
- Scroll Arrow: Updated bottom scroll-to-top arrow color, border, and shadow from blue to green
- Jobs Section: Changed job date ranges and tab hover states from blue to green
- Side Elements: Updated side component colors from blue to green
- Footer: Fixed purple-ish footer text to use consistent black (--dark-brown) like other body text

The site now maintains a cohesive color palette with green (#629677) for accents, orange (#fa824c) for highlights, and consistent black (#57534e) for text. This finalizes elimination of the previous visual inconsistency of scattered blue elements.