### PR TITLE
Finalized color palette transition

### DIFF
--- a/src/components/sections/about.js
+++ b/src/components/sections/about.js
@@ -33,7 +33,7 @@ const StyledText = styled.div`
     list-style: none;
 
     li {
-      color: var(--soft-green);
+      color: var(--secondary-green);
       position: relative;
       margin-bottom: 10px;
       padding-left: 20px;

--- a/src/components/sections/featured.js
+++ b/src/components/sections/featured.js
@@ -124,7 +124,7 @@ const StyledProject = styled.li`
   }
 
   .project-title {
-    color: var(--tertiary-purple);
+    color: var(--dark-brown);
     font-size: clamp(24px, 5vw, 28px);
 
     @media (min-width: 768px) {


### PR DESCRIPTION
Updated the About section's technology list text from the brighter --soft-green to the consistent --secondary-green used throughout the rest of the site, and changed featured project titles from purple (--tertiary-purple) to the standard black text color (--dark-brown). These changes ensure all green accents and text colors maintain consistency with the established green/orange/black color scheme across the entire application.